### PR TITLE
Add AI suggestions to LaTeX editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI LaTeX Editor
 
 Simple web-based LaTeX editor with PDF compilation using `pdflatex`.
+Now includes basic AI suggestions powered by the OpenAI API.
 
 ## Usage
 
@@ -13,6 +14,10 @@ Simple web-based LaTeX editor with PDF compilation using `pdflatex`.
    node server.js
    ```
 3. Open [http://localhost:3000](http://localhost:3000) in your browser to edit LaTeX and compile PDFs.
+
+### AI Suggestions
+
+Set the `OPENAI_API_KEY` environment variable to enable the AI suggestion feature.
 
 ## Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "openai": "^5.6.0"
       }
     },
     "node_modules/accepts": {
@@ -536,6 +537,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.6.0.tgz",
+      "integrity": "sha512-jNH5z+hYAdOMZXyEt0yZ7246s+UZjg2AwFQqkAhZIPPjxNtHHO5mykOefau6FkOqj16aC94MOdJl/rZBcKj/cQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "openai": "^5.6.0"
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -14,3 +14,18 @@ document.getElementById('compile').addEventListener('click', async () => {
     alert('Compilation failed');
   }
 });
+
+document.getElementById('aisuggest').addEventListener('click', async () => {
+  const text = document.getElementById('editor').value;
+  const res = await fetch('/suggest', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('suggestion').value = data.suggestion;
+  } else {
+    alert('AI suggestion failed');
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,9 @@ Hello, world!
 </textarea>
   <br>
   <button id="compile">Compile PDF</button>
+  <button id="aisuggest">AI Suggest</button>
+  <br>
+  <textarea id="suggestion" rows="5" cols="80" readonly placeholder="AI suggestions will appear here..."></textarea>
   <br>
   <iframe id="preview" style="width:100%; height:500px;"></iframe>
 

--- a/public/style.css
+++ b/public/style.css
@@ -15,3 +15,12 @@ button {
   margin-top: 10px;
   padding: 8px 16px;
 }
+
+#suggestion {
+  width: 100%;
+  max-width: 800px;
+  margin-top: 10px;
+  background-color: #1e1e1e;
+  color: #f1f1f1;
+  border: 1px solid #333;
+}

--- a/server.js
+++ b/server.js
@@ -2,6 +2,11 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
+const { Configuration, OpenAIApi } = require('openai');
+
+const openai = new OpenAIApi(new Configuration({
+  apiKey: process.env.OPENAI_API_KEY
+}));
 
 const app = express();
 app.use(express.json({ limit: '1mb' }));
@@ -29,6 +34,26 @@ app.post('/compile', (req, res) => {
       res.status(500).send('PDF not generated');
     }
   });
+});
+
+app.post('/suggest', async (req, res) => {
+  const text = req.body.text;
+  if (!text) return res.status(400).send('No text provided');
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant for LaTeX editing.' },
+        { role: 'user', content: text }
+      ],
+      max_tokens: 150
+    });
+    const suggestion = completion.data.choices[0].message.content.trim();
+    res.json({ suggestion });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('AI suggestion failed');
+  }
 });
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- integrate OpenAI API for suggestions
- expose `/suggest` endpoint on the server
- add AI button and suggestion area in the client
- style the new suggestion box
- update README with setup instructions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857a8e11040833190411833126b185a