### PR TITLE
Update OpenAI initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Now includes basic AI suggestions powered by the OpenAI API.
 ### AI Suggestions
 
 Set the `OPENAI_API_KEY` environment variable to enable the AI suggestion feature.
+The project uses version 5 of the `openai` package, so the client is
+initialized in `server.js` using `new OpenAI({ apiKey: ... })`.
 
 ## Notes
 

--- a/server.js
+++ b/server.js
@@ -2,11 +2,12 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
-const { Configuration, OpenAIApi } = require('openai');
+const OpenAI = require('openai');
 
-const openai = new OpenAIApi(new Configuration({
+// Initialize the OpenAI client using the v5+ API style
+const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY
-}));
+});
 
 const app = express();
 app.use(express.json({ limit: '1mb' }));


### PR DESCRIPTION
## Summary
- initialize OpenAI client with v5 syntax
- document OpenAI v5 initialization in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6857aab10fc483319be89dfdbdb68ef8